### PR TITLE
Fixing bgl error

### DIFF
--- a/source/operators/handles.py
+++ b/source/operators/handles.py
@@ -17,7 +17,7 @@ import bpy
 import mathutils
 import math
 import gpu
-import bgl
+#import bgl
 
 from gpu_extras.batch import batch_for_shader
 from bpy_extras import view3d_utils


### PR DESCRIPTION
As `bgl` is deprecated, it's been commented out everywhere else in the code base - it was missed in this one place, causing an issue on install in recent Blender versions. This fixes it.